### PR TITLE
Adapt travis for libosmium and C++11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,73 +1,47 @@
 language: cpp
-
+sudo: false
 addons:
   apt:
+    sources:
+    - boost-latest
+    - ubuntu-toolchain-r-test
     packages:
+    - g++-4.8
     - libtool
-    - libxml2-dev
+    - libexpat1-dev
+    - libprotobuf-dev
+    - protobuf-compiler
     - libgeos-dev
     - libgeos++-dev
     - libpq-dev
     - libbz2-dev
     - libproj-dev
-    - protobuf-c-compiler
-    - libprotobuf-c0-dev
-
+    - lua5.2
+    - liblua5.2-dev
+    - libboost1.55-dev
+    - libboost-system1.55-dev
+    - libboost-filesystem1.55-dev
+    - libboost-thread1.55-dev
 matrix:
   include:
-    #basic tests of with/without lua and old boost versions, with both clang and gc
     - os: linux
       compiler: clang
-      env: USE_LUA=true
-    - os: linux
-      compiler: clang
-      env: USE_LUA=true BOOST_PPA=1.55
-    - os: linux
-      compiler: clang
-      env: USE_LUA=false BOOST_PPA=1.55
     - os: linux
       compiler: gcc
-      env: USE_LUA=true
-    - os: linux
-      compiler: gcc
-      env: USE_LUA=true BOOST_PPA=1.55
-    - os: linux
-      compiler: gcc
-      env: USE_LUA=false BOOST_PPA=1.55
-    # additional tests
-    - os: linux
-      compiler: clang
-      env: USE_LUA=true BOOST_PPA=1.54
-
-before_install:
-  # BOOST_PPA is only set on linux
-  - if [ -z ${BOOST_PPA+x} ]; then
-      echo "Using system Boost";
-    else
-      echo "Using Boost PPA";
-      sudo add-apt-repository -y ppa:boost-latest/ppa;
-    fi
-  - if [[ $(uname -s) == 'Linux' ]]; then
-      sudo apt-get update -qq;
-    fi
+# update versions
 install:
-  - if [[ $(uname -s) == 'Linux' ]]; then
-      if [ -z ${BOOST_PPA+x} ]; then
-        sudo apt-get install -y -qq libboost1.48-all-dev;
-      else
-        sudo apt-get install -y -qq "boost${BOOST_PPA}";
-      fi;
-      if [[ "${USE_LUA}" = "true" ]]; then
-        sudo apt-get install -y -qq lua5.2 liblua5.2-dev;
-      fi;
-    fi;
+  - if [[ $CC == 'gcc' ]]; then
+      export CC=gcc-4.8;
+    fi
+  - if [[ $CXX == 'g++' ]]; then
+      export CXX=g++-4.8;
+    fi
 before_script:
+  - $CXX --version
   - xml2-config --version
   - geos-config --version
   - proj | head -n1
-  - if [ "${USE_LUA}" = "true" ]; then
-      lua -v;
-    fi;
+  - lua -v
 script:
   ./autogen.sh && ./configure && make -j2
 after_failure:


### PR DESCRIPTION
With --without-lockfree gone, only one boost version is now needed.
This means the container-based infrastructure can now be used, with its advantages.
