### PR TITLE
workaround for multithreading locale problem in GEOS

### DIFF
--- a/osmdata.cpp
+++ b/osmdata.cpp
@@ -170,6 +170,10 @@ struct pending_threaded_processor : public middle_t::pending_processor {
     typedef std::pair<std::shared_ptr<const middle_query_t>, output_vec_t> clone_t;
 
     static void do_jobs(output_vec_t const& outputs, pending_queue_t& queue, size_t& ids_done, std::mutex& mutex, int append, bool ways) {
+#ifdef _MSC_VER
+	// Avoid problems when GEOS WKT-related methods switch the locale
+        _configthreadlocale(_ENABLE_PER_THREAD_LOCALE);
+#endif
         while (true) {
             //get the job off the queue synchronously
             pending_job_t job;


### PR DESCRIPTION
Found it here: https://msdn.microsoft.com/en-us/library/ms235302.aspx
